### PR TITLE
[bugfix] Fix NPE in designer export command

### DIFF
--- a/crp-flowable-shell/src/main/java/org/crp/flowable/shell/commands/Designer.java
+++ b/crp-flowable-shell/src/main/java/org/crp/flowable/shell/commands/Designer.java
@@ -3,6 +3,7 @@ package org.crp.flowable.shell.commands;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -10,6 +11,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.crp.flowable.shell.configuration.FlowableShellProperties;
+import org.crp.flowable.shell.model.ShellCommandException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,11 +26,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 
 @ShellCommandGroup
 @ShellComponent
 public class Designer {
     private static final Logger LOGGER = LoggerFactory.getLogger(Designer.class);
+    private static final String FLOWABLE_JSON_PROP_MESSAGE = "message";
+    private static final String FLOWABLE_JSON_PROP_RESULT = "result";
+    private static final String FLOWABLE_JSON_PROP_EXCEPTION = "exception";
 
     @Autowired
     protected ObjectMapper objectMapper;
@@ -55,21 +61,26 @@ public class Designer {
                         return objectMapper.createObjectNode().put("result", "ok").put("message", "Model " + workspace + "/" +name + " stored in "+outputFile.getCanonicalPath());
                     }
                 } else {
-                    LOGGER.error("Unable to complete rest call errorCode {}", httpResponse.getStatusLine().getStatusCode());
+                    int httpStatusCode = httpResponse.getStatusLine().getStatusCode();
+                    LOGGER.error("Unable to complete rest call errorCode {}", httpStatusCode);
                     try(InputStream content = httpResponse.getEntity().getContent()) {
                         JsonNode response = objectMapper.readTree(content);
-                        throw new RuntimeException(response.get("message").asText() + "\n" + response.get("exception").asText());
+                        if (response.has(FLOWABLE_JSON_PROP_MESSAGE) && response.has(FLOWABLE_JSON_PROP_EXCEPTION)) {
+                            throw new ShellCommandException(response.get(FLOWABLE_JSON_PROP_MESSAGE).asText() + "\n" + response.get(FLOWABLE_JSON_PROP_EXCEPTION).asText());
+                        } else {
+                            throw new ShellCommandException(String.format("Unable to export model: \nuri=%s\nhttpStatusCode=%s\nresponseBody=%s", uri, httpStatusCode, IOUtils.toString(content, StandardCharsets.UTF_8)));
+                        }
                     }
                 }
             }
         } catch (IOException | URISyntaxException e) {
-            throw new RuntimeException(e);
+            throw new ShellCommandException("Unable to export model", e);
         }
     }
 
     private void addAuthorization(HttpRequestBase httpRequest) {
         if (!StringUtils.hasLength(properties.getToken())) {
-            throw new RuntimeException("Access token not set. Please set 'FLOWABLE_TOKEN' system variable or 'crp.flowable.shell.token' property.");
+            throw new ShellCommandException("Access token not set. Please set 'FLOWABLE_TOKEN' system variable or 'crp.flowable.shell.token' property.");
         }
         httpRequest.addHeader("Authorization", "Bearer "+ properties.getToken());
     }

--- a/crp-flowable-shell/src/main/java/org/crp/flowable/shell/model/ShellCommandException.java
+++ b/crp-flowable-shell/src/main/java/org/crp/flowable/shell/model/ShellCommandException.java
@@ -1,0 +1,12 @@
+package org.crp.flowable.shell.model;
+
+public class ShellCommandException extends RuntimeException {
+
+  public ShellCommandException(String message) {
+    super(message);
+  }
+
+  public ShellCommandException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
A `NullpointerException` could previously have been thrown on an empty body response or when the JSON is not containing a message or exception property. E.g. HTTP 401. It will now instead throw an exception with the code &
responseBody (if any)